### PR TITLE
Update scheduled function resource type

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -39,7 +39,7 @@ contributors:
 # Learn more in the docs: https://firebase.google.com/docs/extensions/alpha/ref-extension-yaml#resources-field
 resources:
   - name: scheduledFirestoreBackup
-    type: firebaseextensions.v1beta.scheduledFunction
+    type: firebaseextensions.v1beta.function
     description: >-
       Backup the Firestore data
     properties:


### PR DESCRIPTION
API Change: As of May 21, the scheduled function resource type changes from 

`firebaseextensions.v1beta.scheduledFunction`

to

`firebaseextensions.v1beta.function`

This doesn't affect already-deployed extensions, but will affect new installs.